### PR TITLE
Detect the ACM and MCE namespaces in case the default isn't used

### DIFF
--- a/src/supervisor/container.py
+++ b/src/supervisor/container.py
@@ -110,14 +110,14 @@ def restartCount(pc,startTime, endTime, step):
     print("Checking if ACM pods are restarting frequently")
 
     try:
-        restart_data = pc.custom_query('sum(kube_pod_container_status_restarts_total{namespace=~"multicluster-engine|open-cluster-managemen.+"}) by (namespace,container)')
+        restart_data = pc.custom_query('sum(kube_pod_container_status_restarts_total{namespace=~"'+getACMNamespacesExpression()+'"}) by (namespace,container)')
         restart_data_df = MetricSnapshotDataFrame(restart_data)
         restart_data_df["value"]=restart_data_df["value"].astype(int)
         restart_data_df.rename(columns={"value": "RestartCount"}, inplace = True)
         print(restart_data_df[['container','namespace','RestartCount']].to_markdown())
 
         restart_data_trend = pc.custom_query_range(
-        query='sum(kube_pod_container_status_restarts_total{namespace=~"multicluster-engine|open-cluster-managemen.+"}) by (namespace)',
+        query='sum(kube_pod_container_status_restarts_total{namespace=~"'+getACMNamespacesExpression()+'"}) by (namespace)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -184,14 +184,14 @@ def checkContainerCount(pc,startTime, endTime, step):
     print("Checking number of Pods running in the ACM namespaces")
 
     try:
-        container_data = pc.custom_query('sum by (namespace) (kube_pod_info{namespace=~"open-cluster-managemen.+"})')
+        container_data = pc.custom_query('sum by (namespace) (kube_pod_info{namespace=~"'+getACMNamespacesExpression()+'"})')
         container_data_df = MetricSnapshotDataFrame(container_data)
         container_data_df["value"]=container_data_df["value"].astype(int)
         container_data_df.rename(columns={"value": "PodCount"}, inplace = True)
         print(container_data_df[['namespace','PodCount']].to_markdown())
 
         container_data_trend = pc.custom_query_range(
-        query='sum by (namespace) (kube_pod_info{namespace=~"open-cluster-managemen.+"})',
+        query='sum by (namespace) (kube_pod_info{namespace=~"'+getACMNamespacesExpression()+'"})',
             start_time=startTime,
             end_time=endTime,
             step=step,

--- a/src/supervisor/cpuAnalysis.py
+++ b/src/supervisor/cpuAnalysis.py
@@ -271,7 +271,7 @@ def ACMCPUUsage(pc,startTime, endTime, step):
     print("Total ACM CPU Core usage")
 
     try:
-        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"multicluster-engine|open-cluster-.+"})')
+        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"'+getACMNamespacesExpression()+'"})')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -279,7 +279,7 @@ def ACMCPUUsage(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMCPUCoreUsage']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"multicluster-engine|open-cluster-.+"})',
+        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"'+getACMNamespacesExpression()+'"})',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -308,7 +308,7 @@ def ACMDetailCPUUsage(pc,startTime, endTime, step):
     print("Detailed ACM CPU Core usage")
 
     try:
-        acm_detail_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"multicluster-engine|open-cluster-.+"}) by (namespace)')
+        acm_detail_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"'+getACMNamespacesExpression()+'"}) by (namespace)')
 
         acm_detail_cpu_df = MetricSnapshotDataFrame(acm_detail_cpu)
         acm_detail_cpu_df["value"]=acm_detail_cpu_df["value"].astype(float)
@@ -316,7 +316,7 @@ def ACMDetailCPUUsage(pc,startTime, endTime, step):
         print(acm_detail_cpu_df[['namespace','CPUCoreUsage']].to_markdown())
 
         acm_detail_cpu_trend = pc.custom_query_range(
-        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"multicluster-engine|open-cluster-.+"}) by (namespace)',
+        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"'+getACMNamespacesExpression()+'"}) by (namespace)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -345,7 +345,7 @@ def OtherCPUUsage(pc,startTime, endTime, step):
     print("Total CPU Core usage - Other")
 
     try:
-        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace!~"multicluster-engine|open-cluster-.+|openshift-kube-apiserver|openshift-etcd"})')
+        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace!~"'+getACMNamespacesExpressionNoObs()+'"})')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -353,7 +353,7 @@ def OtherCPUUsage(pc,startTime, endTime, step):
         print(acm_cpu_df[['OtherCPUCoreUsage']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace!~"multicluster-engine|open-cluster-.+|openshift-kube-apiserver|openshift-etcd"})',
+        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace!~"'+getACMNamespacesExpression()+'|openshift-kube-apiserver|openshift-etcd"})',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -382,7 +382,7 @@ def OtherDetailCPUUsage(pc,startTime, endTime, step):
     print("Total CPU Core usage Detail - Other")
 
     try:
-        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace!~"multicluster-engine|open-cluster-.+|openshift-kube-apiserver|openshift-etcd"}) by (namespace)')
+        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace!~"'+getACMNamespacesExpression()+'|openshift-kube-apiserver|openshift-etcd"}) by (namespace)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -390,7 +390,7 @@ def OtherDetailCPUUsage(pc,startTime, endTime, step):
         print(acm_cpu_df[['namespace','OtherCPUCoreUsage']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace!~"multicluster-engine|open-cluster-.+|openshift-kube-apiserver|openshift-etcd"}) by (namespace)',
+        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace!~"'+getACMNamespacesExpression()+'|openshift-kube-apiserver|openshift-etcd"}) by (namespace)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -456,7 +456,7 @@ def ACMOtherCPUUsage(pc,startTime, endTime, step):
     print("Total ACM Other CPU Core usage")
 
     try:
-        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"multicluster-engine|open-cluster-management-agent.+|open-cluster-management-hub|open-cluster-management-addon.+"})')
+        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"'+getACMNamespacesExpressionNoObs()+'"})')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -464,7 +464,7 @@ def ACMOtherCPUUsage(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMOthCPUCoreUsage']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"multicluster-engine|open-cluster-management-agent.+|open-cluster-management-hub|open-cluster-management-addon.+"})',
+        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~"'+getACMNamespacesExpressionNoObs()+'"})',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -567,7 +567,7 @@ def ACMSrcPGCPUUsage(pc,startTime, endTime, step):
     print("Total ACM Search Postgres CPU Core usage")
 
     try:
-        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="open-cluster-management",container="search-postgres"})')
+        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="'+getACMNamespace()+'",container="search-postgres"})')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -575,7 +575,7 @@ def ACMSrcPGCPUUsage(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMSrcPGCPUCoreUsage']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="open-cluster-management",container="search-postgres"})',
+        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="'+getACMNamespace()+'",container="search-postgres"})',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -604,7 +604,7 @@ def ACMSrcIdxCPUUsage(pc,startTime, endTime, step):
     print("Total ACM Search Indexer CPU Core usage")
 
     try:
-        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="open-cluster-management",container="search-indexer"})')
+        acm_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="'+getACMNamespace()+'",container="search-indexer"})')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -612,7 +612,7 @@ def ACMSrcIdxCPUUsage(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMSrcIdxCPUCoreUsage']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="open-cluster-management",container="search-indexer"})',
+        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="'+getACMNamespace()+'",container="search-indexer"})',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -641,7 +641,7 @@ def ACMOCMDetailCPUUsage(pc,startTime, endTime, step):
     print("Detailed ACM Open CLuster Management CPU Core usage")
 
     try:
-        acm_detail_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="open-cluster-management"}) by (container)')
+        acm_detail_cpu = pc.custom_query('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="'+getACMNamespace()+'"}) by (container)')
 
         acm_detail_cpu_df = MetricSnapshotDataFrame(acm_detail_cpu)
         acm_detail_cpu_df["value"]=acm_detail_cpu_df["value"].astype(float)
@@ -649,7 +649,7 @@ def ACMOCMDetailCPUUsage(pc,startTime, endTime, step):
         print(acm_detail_cpu_df[['container','CPUCoreUsage']].to_markdown())
 
         acm_detail_cpu_trend = pc.custom_query_range(
-        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="open-cluster-management"}) by (container)',
+        query='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="'+getACMNamespace()+'"}) by (container)',
             start_time=startTime,
             end_time=endTime,
             step=step,

--- a/src/supervisor/entry.py
+++ b/src/supervisor/entry.py
@@ -48,6 +48,7 @@ def main():
    
     createSubdir()
     mch = checkMCHStatus()
+    mce = checkMCEStatus()
     node = checkNodeStatus()
 
     if tsdb == "prom" : #if route is cluster prom

--- a/src/supervisor/mch.py
+++ b/src/supervisor/mch.py
@@ -4,6 +4,7 @@ from colorama import Fore, Back, Style
 import sys
 #import urllib3
 #urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+import utility
 
 def checkMCHStatus(debug=False):
     
@@ -20,7 +21,7 @@ def checkMCHStatus(debug=False):
 
     v1 = client.CustomObjectsApi()
     try:
-        mcs = v1.list_namespaced_custom_object(group="operator.open-cluster-management.io", version="v1", plural="multiclusterhubs", namespace="open-cluster-management", _request_timeout=1)
+        mcs = v1.list_namespaced_custom_object(group="operator.open-cluster-management.io", version="v1", plural="multiclusterhubs", namespace="", _request_timeout=10)
 
         for mc in mcs.get('items', []):
             #print("\n")
@@ -28,6 +29,7 @@ def checkMCHStatus(debug=False):
             if debug: print("Current Version: ",mc['status']['currentVersion'])
             if debug: print("Desired Version: ",mc['status']['desiredVersion'])
             if debug: print("Phase: ",mc['status']['phase'])
+            utility.acmNamespace = mc['metadata']['namespace']
             mch['name']=mc['metadata']['name']
             mch['CurrentVersion']=mc['status']['currentVersion']
             mch['DesiredVersion']=mc['status']['desiredVersion']
@@ -57,3 +59,58 @@ def checkMCHStatus(debug=False):
         print(Style.RESET_ALL)
 
     return status
+
+def checkMCEStatus(debug=False):
+
+    print(Back.LIGHTYELLOW_EX+"")
+    print("************************************************************************************************")
+    print("Multicluster Engine Operator Health Check")
+    print("************************************************************************************************")
+    print(Style.RESET_ALL)
+    status = True
+    mce={}
+
+    # Configs can be set in Configuration class directly or using helper utility
+    config.load_kube_config()
+
+    v1 = client.CustomObjectsApi()
+    try:
+        mcs = v1.list_cluster_custom_object(group="multicluster.openshift.io", version="v1", plural="multiclusterengines", _request_timeout=10)
+
+        for mc in mcs.get('items', []):
+            #print("\n")
+            if debug: print(mc['metadata']['name'])
+            if debug: print("Current Version: ",mc['status']['currentVersion'])
+            if debug: print("Desired Version: ",mc['status']['desiredVersion'])
+            if debug: print("Phase: ",mc['status']['phase'])
+            utility.mceNamespace = mc['spec']['targetNamespace']
+            mce['name']=mc['metadata']['name']
+            mce['CurrentVersion']=mc['status']['currentVersion']
+            mce['DesiredVersion']=mc['status']['desiredVersion']
+            mce['Phase']=mc['status']['phase']
+            for x in mc['status']['conditions']:
+                for k,v in x.items():
+                    if (k=="reason" or k=="status"):
+                        if debug: print(k," : ",v)
+                        if k=="status":
+                            if v=="True":
+                                status = status & True
+                            else:
+                                status = status & False
+            #print("\n")
+            mce['Health']=status
+            print(mce)
+
+        print(Back.LIGHTYELLOW_EX+"")
+        print("************************************************************************************************")
+        print("Multicluster Engine Operator Health Check = ", status)
+        print("************************************************************************************************")
+        print(Style.RESET_ALL)
+
+    except Exception as e:
+        print(Fore.RED+"Failure: ",e)
+        sys.exit("Cluster may be down, or credentials may be wrong, or simply not connected")
+        print(Style.RESET_ALL)
+
+    return status
+

--- a/src/supervisor/memoryAnalysis.py
+++ b/src/supervisor/memoryAnalysis.py
@@ -289,7 +289,7 @@ def ACMMemUsageRSS(pc,startTime, endTime, step):
     print("Total ACM Memory (rss) usage GB")
 
     try:
-        acm_cpu = pc.custom_query('sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"multicluster-engine|open-cluster-.+"})/(1024*1024*1024)')
+        acm_cpu = pc.custom_query('sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"'+getACMNamespacesExpression()+'"})/(1024*1024*1024)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -297,7 +297,7 @@ def ACMMemUsageRSS(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMMemUsageRSSGB']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"multicluster-engine|open-cluster-.+"})/(1024*1024*1024)',
+        query='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"'+getACMNamespacesExpression()+'"})/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -326,7 +326,7 @@ def ACMDetailMemUsageRSS(pc,startTime, endTime, step):
     print("Detailed ACM Memory (rss) usage GB")
 
     try:
-        acm_detail_cpu = pc.custom_query('(sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"multicluster-engine|open-cluster-.+"}) by (namespace))/(1024*1024*1024)')
+        acm_detail_cpu = pc.custom_query('(sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"'+getACMNamespacesExpression()+'"}) by (namespace))/(1024*1024*1024)')
 
         acm_detail_cpu_df = MetricSnapshotDataFrame(acm_detail_cpu)
         acm_detail_cpu_df["value"]=acm_detail_cpu_df["value"].astype(float)
@@ -334,7 +334,7 @@ def ACMDetailMemUsageRSS(pc,startTime, endTime, step):
         print(acm_detail_cpu_df[['namespace','ACMDetailMemUsageRSSGB']].to_markdown())
 
         acm_detail_cpu_trend = pc.custom_query_range(
-        query='(sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"multicluster-engine|open-cluster-.+"}) by (namespace))/(1024*1024*1024)',
+        query='(sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"'+getACMNamespacesExpression()+'"}) by (namespace))/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -473,7 +473,7 @@ def ACMMemUsageWSS(pc,startTime, endTime, step):
     print("Total ACM Memory (wss) usage GB")
 
     try:
-        acm_cpu = pc.custom_query('sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"multicluster-engine|open-cluster-.+"})/(1024*1024*1024)')
+        acm_cpu = pc.custom_query('sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"'+getACMNamespacesExpression()+'"})/(1024*1024*1024)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -481,7 +481,7 @@ def ACMMemUsageWSS(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMMemUsageWSSGB']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"multicluster-engine|open-cluster-.+"})/(1024*1024*1024)',
+        query='sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"'+getACMNamespacesExpression()+'"})/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -510,7 +510,7 @@ def ACMDetailMemUsageWSS(pc,startTime, endTime, step):
     print("Detailed ACM Memory (wss) usage GB")
 
     try:
-        acm_detail_cpu = pc.custom_query('(sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"multicluster-engine|open-cluster-.+"}) by (namespace))/(1024*1024*1024)')
+        acm_detail_cpu = pc.custom_query('(sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"'+getACMNamespacesExpression()+'"}) by (namespace))/(1024*1024*1024)')
 
         acm_detail_cpu_df = MetricSnapshotDataFrame(acm_detail_cpu)
         acm_detail_cpu_df["value"]=acm_detail_cpu_df["value"].astype(float)
@@ -518,7 +518,7 @@ def ACMDetailMemUsageWSS(pc,startTime, endTime, step):
         print(acm_detail_cpu_df[['namespace','ACMDetailMemUsageWSSGB']].to_markdown())
 
         acm_detail_cpu_trend = pc.custom_query_range(
-        query='(sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"multicluster-engine|open-cluster-.+"}) by (namespace))/(1024*1024*1024)',
+        query='(sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"'+getACMNamespacesExpression()+'"}) by (namespace))/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -694,7 +694,7 @@ def ACMOtherMemUsageRSS(pc,startTime, endTime, step):
     print("Total ACM Others Memory (rss) usage GB")
 
     try:
-        acm_cpu = pc.custom_query('sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"multicluster-engine|open-cluster-management|open-cluster-management-agent.+|open-cluster-management-hub|open-cluster-management-addon.+"})/(1024*1024*1024)')
+        acm_cpu = pc.custom_query('sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"'+getACMNamespacesExpressionNoObs()+'"})/(1024*1024*1024)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -702,7 +702,7 @@ def ACMOtherMemUsageRSS(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMOthMemUsageRSSGB']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"multicluster-engine|open-cluster-management-agent.+|open-cluster-management-hub|open-cluster-management-addon.+"})/(1024*1024*1024)',
+        query='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace=~"'+getACMNamespacesExpressionNoObs()+'"})/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -731,7 +731,7 @@ def ACMOtherMemUsageWSS(pc,startTime, endTime, step):
     print("Total ACM Other Memory (wss) usage GB")
 
     try:
-        acm_cpu = pc.custom_query('sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"multicluster-engine|open-cluster-management-agent.+|open-cluster-management-hub|open-cluster-management-addon.+"})/(1024*1024*1024)')
+        acm_cpu = pc.custom_query('sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"'+getACMNamespacesExpressionNoObs()+'"})/(1024*1024*1024)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -739,7 +739,7 @@ def ACMOtherMemUsageWSS(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMOthMemUsageWSSGB']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"multicluster-engine|open-cluster-management-agent.+|open-cluster-management-hub|open-cluster-management-addon.+"})/(1024*1024*1024)',
+        query='sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace=~"'+getACMNamespacesExpressionNoObs()+'"})/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -914,7 +914,7 @@ def ACMOCMDetailMemUsageRSS(pc,startTime, endTime, step):
     print("Detailed ACM Open cluster management Memory (rss) usage GB")
 
     try:
-        acm_detail_cpu = pc.custom_query('(sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace="open-cluster-management"}) by (container))/(1024*1024*1024)')
+        acm_detail_cpu = pc.custom_query('(sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace="'+getACMNamespace()+'"}) by (container))/(1024*1024*1024)')
 
         acm_detail_cpu_df = MetricSnapshotDataFrame(acm_detail_cpu)
         acm_detail_cpu_df["value"]=acm_detail_cpu_df["value"].astype(float)
@@ -922,7 +922,7 @@ def ACMOCMDetailMemUsageRSS(pc,startTime, endTime, step):
         print(acm_detail_cpu_df[['container','ACMOCMDetailMemUsageRSSGB']].to_markdown())
 
         acm_detail_cpu_trend = pc.custom_query_range(
-        query='(sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace="open-cluster-management"}) by (container))/(1024*1024*1024)',
+        query='(sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", namespace="'+getACMNamespace()+'"}) by (container))/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -950,7 +950,7 @@ def ACMOCMDetailMemUsageWSS(pc,startTime, endTime, step):
     print("Detailed ACM Open cluster management Memory (wss) usage GB")
 
     try:
-        acm_detail_cpu = pc.custom_query('(sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace="open-cluster-management"}) by (container))/(1024*1024*1024)')
+        acm_detail_cpu = pc.custom_query('(sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace="'+getACMNamespace()+'"}) by (container))/(1024*1024*1024)')
 
         acm_detail_cpu_df = MetricSnapshotDataFrame(acm_detail_cpu)
         acm_detail_cpu_df["value"]=acm_detail_cpu_df["value"].astype(float)
@@ -958,7 +958,7 @@ def ACMOCMDetailMemUsageWSS(pc,startTime, endTime, step):
         print(acm_detail_cpu_df[['container','ACMOCMDetailMemUsageWSSGB']].to_markdown())
 
         acm_detail_cpu_trend = pc.custom_query_range(
-        query='(sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace="open-cluster-management"}) by (container))/(1024*1024*1024)',
+        query='(sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!="", image!="",namespace="'+getACMNamespace()+'"}) by (container))/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -986,7 +986,7 @@ def ACMSrcPGvMemUsageRSS(pc,startTime, endTime, step):
     print("Total ACM Search Postgres Memory (rss) usage GB")
 
     try:
-        acm_cpu = pc.custom_query('sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-postgres", namespace="open-cluster-management"})/(1024*1024*1024)')
+        acm_cpu = pc.custom_query('sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-postgres", namespace="'+getACMNamespace()+'"})/(1024*1024*1024)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -994,7 +994,7 @@ def ACMSrcPGvMemUsageRSS(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMSearchPGMemUsageRSSGB']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-postgres", namespace="open-cluster-management"})/(1024*1024*1024)',
+        query='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-postgres", namespace="'+getACMNamespace()+'"})/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -1023,7 +1023,7 @@ def ACMOSrcPGMemUsageWSS(pc,startTime, endTime, step):
     print("Total ACM Search Postgres Memory (wss) usage GB")
 
     try:
-        acm_cpu = pc.custom_query('sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-postgres", image!="",namespace="open-cluster-management"})/(1024*1024*1024)')
+        acm_cpu = pc.custom_query('sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-postgres", image!="",namespace="'+getACMNamespace()+'"})/(1024*1024*1024)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -1031,7 +1031,7 @@ def ACMOSrcPGMemUsageWSS(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMSearchPGMemUsageWSSGB']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-postgres", image!="",namespace="open-cluster-management"})/(1024*1024*1024)',
+        query='sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-postgres", image!="",namespace="'+getACMNamespace()+'"})/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -1060,7 +1060,7 @@ def ACMSrcIdxvMemUsageRSS(pc,startTime, endTime, step):
     print("Total ACM Search Indexer Memory (rss) usage GB")
 
     try:
-        acm_cpu = pc.custom_query('sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-indexer", namespace="open-cluster-management"})/(1024*1024*1024)')
+        acm_cpu = pc.custom_query('sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-indexer", namespace="'+getACMNamespace()+'"})/(1024*1024*1024)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -1068,7 +1068,7 @@ def ACMSrcIdxvMemUsageRSS(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMSearchIdxMemUsageRSSGB']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-indexer", namespace="open-cluster-management"})/(1024*1024*1024)',
+        query='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-indexer", namespace="'+getACMNamespace()+'"})/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,
@@ -1097,7 +1097,7 @@ def ACMOSrcIdxMemUsageWSS(pc,startTime, endTime, step):
     print("Total ACM Search Indexer Memory (wss) usage GB")
 
     try:
-        acm_cpu = pc.custom_query('sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-indexer", image!="",namespace="open-cluster-management"})/(1024*1024*1024)')
+        acm_cpu = pc.custom_query('sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-indexer", image!="",namespace="'+getACMNamespace()+'"})/(1024*1024*1024)')
 
         acm_cpu_df = MetricSnapshotDataFrame(acm_cpu)
         acm_cpu_df["value"]=acm_cpu_df["value"].astype(float)
@@ -1105,7 +1105,7 @@ def ACMOSrcIdxMemUsageWSS(pc,startTime, endTime, step):
         print(acm_cpu_df[['ACMSearchIdxMemUsageWSSGB']].to_markdown())
 
         acm_cpu_trend = pc.custom_query_range(
-        query='sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-indexer", image!="",namespace="open-cluster-management"})/(1024*1024*1024)',
+        query='sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container="search-indexer", image!="",namespace="'+getACMNamespace()+'"})/(1024*1024*1024)',
             start_time=startTime,
             end_time=endTime,
             step=step,

--- a/src/supervisor/node.py
+++ b/src/supervisor/node.py
@@ -28,7 +28,7 @@ def checkNodeStatus(debug=False):
     #     print("%s\t%s\t%s" % (i.status.pod_ip, i.metadata.namespace, i.metadata.name))
 
     try:
-        nodes=v1.list_node(_request_timeout=1) 
+        nodes=v1.list_node(_request_timeout=10) 
         nodeDetailsList=[] 
         node_df = pandas.DataFrame()
         for node in nodes.items:

--- a/src/supervisor/sizing.py
+++ b/src/supervisor/sizing.py
@@ -120,7 +120,7 @@ def restartCount(pc):
     print("Checking if ACM pods are restarting frequently")
 
     try:
-        restart_data = pc.custom_query('sum(kube_pod_container_status_restarts_total{namespace=~"open-cluster-managemen.+",cluster="local-cluster"}) by (namespace,container) >0')
+        restart_data = pc.custom_query('sum(kube_pod_container_status_restarts_total{namespace=~"'+getACMNamespacesExpression()+'",cluster="local-cluster"}) by (namespace,container) >0')
         restart_data_df = MetricSnapshotDataFrame(restart_data);
         restart_data_df["value"]=restart_data_df["value"].astype(int)
         restart_data_df.rename(columns={"value": "RestartCount"}, inplace = True)
@@ -156,7 +156,7 @@ def checkContainerCount(pc):
 
     print("Checking number of Pods running in the ACM namespaces")
 
-    container_data = pc.custom_query('sum by (namespace) (kube_pod_info{namespace=~"open-cluster-managemen.+"})')
+    container_data = pc.custom_query('sum by (namespace) (kube_pod_info{namespace=~"'+getACMNamespacesExpression()+'"})')
 
     container_data_df = MetricSnapshotDataFrame(container_data);
     container_data_df["value"]=container_data_df["value"].astype(int)

--- a/src/supervisor/utility.py
+++ b/src/supervisor/utility.py
@@ -13,6 +13,21 @@ initialDF = pandas.DataFrame()
 masterDF = pandas.DataFrame()
 nodeDetails={}
 
+acmNamespace = "open-cluster-management"
+mceNamespace = "multicluster-engine"
+
+def getACMNamespace() :
+    global acmNamespace
+    return acmNamespace
+
+def getACMNamespacesExpression() :
+    global acmNamespace, mceNamespace
+    return mceNamespace+"|"+acmNamespace+"|open-cluster-managemen.+"
+
+def getACMNamespacesExpressionNoObs() :
+    global acmNamespace, mceNamespace
+    return mceNamespace+"|"+acmNamespace+"|open-cluster-management-agent.+|open-cluster-management-hub|open-cluster-management-addon.+"
+
 def setNodeDetails(details) :
     
     nodeDetails['numNodes']=details['numNodes']


### PR DESCRIPTION
The inspector was using hard coded namespaces for ACM and MCE.  This caused problems when I tried to investigate a performance problem and wanted to use the inspector. It did not recognize ACM in the `ocm` namespace.  Please consider cases where I may have added the MCE namespace or could have changed the pattern in your review.  I also updated a couple timeouts due to my slow internet or maybe the slow hub I am trying to analyze in the referenced issue.

Refs:
 - https://issues.redhat.com/browse/ACM-16868