### PR TITLE
Fix import errors(timedelta, PrometheusConnect) and Docker build error(Unknown compiler).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,12 @@ RUN microdnf update -y \
 COPY --from=builder /usr/bin/oc /usr/bin/oc
 
 COPY /src/supervisor/requirements.txt ./
-RUN pip3 install -r requirements.txt
+
+# Upgrade pip to get better wheel support
+RUN pip3 install --no-cache-dir --upgrade pip
+
+# Prefer binary wheels to avoid compilation
+RUN pip3 install --no-cache-dir --prefer-binary -r requirements.txt
 
 RUN mkdir acm-inspector
 

--- a/src/supervisor/entry.py
+++ b/src/supervisor/entry.py
@@ -17,7 +17,7 @@ from colorama import Fore, Back, Style
 import urllib3
 import sys
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-from datetime import datetime
+from datetime import datetime, timedelta
 import matplotlib.pyplot as plt
 import os
 

--- a/src/supervisor/utility.py
+++ b/src/supervisor/utility.py
@@ -1,5 +1,5 @@
 import os
-from prometheus_api_client import *
+from prometheus_api_client import PrometheusConnect
 from kubernetes import client, config
 import sys
 import datetime


### PR DESCRIPTION
## Summary

  Fix import errors(timedelta, PrometheusConnect) and Docker build error(Unknown compiler).

  ## Changes

  - Add missing `timedelta` import in `entry.py`
  - Replace wildcard import with explicit `PrometheusConnect` import in `utility.py`
  - Fix Dockerfile to use pre-built wheels:
      - Upgrade pip for better wheel support
      - Use `--prefer-binary` to avoid source compilation
      - Add `--no-cache-dir` to reduce image size

  ## Testing

  - [x] Docker build completes successfully
  - [x] acm-inspector runs without errors
  - [x] All Python dependencies install from wheels